### PR TITLE
Support standard AudioContext constructor

### DIFF
--- a/src/hum/core.cljs
+++ b/src/hum/core.cljs
@@ -57,4 +57,6 @@
     (.linearRampToValueAtTime (.-gain output) 0.0 (+ time 0.1))))
 
 (defn create-context []
-  (js/webkitAudioContext.))
+  (let [constructor (or js/window.AudioContext
+                        js/window.webkitAudioContext)]
+    (constructor.)))


### PR DESCRIPTION
This small change gets Hum (or at least the little demo in the readme) working in Firefox. Tested in Firefox 25.0 and Chromium 30.0 on Linux.
