### PR TITLE
Fixed #4 (hum/create-osc ctx :sawtooth) now creates a sawtooth wave instead of a sine.

### DIFF
--- a/src/hum/core.cljs
+++ b/src/hum/core.cljs
@@ -1,18 +1,11 @@
 (ns hum.core)
 
-(defn get-osc-type [osc type]
-  (condp = type
-    :sawtooth (.-SAWTOOTH osc)
-    :sine (.-SINE osc)
-    :square (.-SQUARE osc)
-    :triangle (.-TRIANGLE osc)))
-
 (defn create-osc
   ([ctx]
      (.createOscillator ctx))
   ([ctx type]
      (let [osc (.createOscillator ctx)
-           osc-type (get-osc-type osc type)]
+           osc-type (name type)]
        (set! (.-type osc) osc-type)
        osc)))
 


### PR DESCRIPTION
Setting oscillator type now works.
