### PR TITLE
Added helper functions for constructing and triggering envelopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Add this to your requires in `project.clj`:
 Here's an example:
 ```clojure
 (ns myapp.core
-  (:require [hum.core :as hum])
+  (:require [hum.core :as hum]
+  	    [hum.envelope :as envelope])
 
 ; create a WebAudio contet
 (defonce ctx (hum/create-context))
@@ -40,9 +41,9 @@ Here's an example:
 (hum/connect-output amp)
 
 ; move filter frequency between values using an exponential envelope.
-(hum/trigger-env vcf :frequency 
-                 (hum/exponential-env [100 10000 1000 5000 100] [4 3 2 1])
-                 (hum/curr-time ctx))
+(envelope/trigger vcf :frequency 
+                  (envelope/exponential [100 10000 1000 5000 100] [4 3 2 1])
+                  (hum/curr-time ctx))
 
 ; set envelope for amp
 (hum/set-value-at amp :gain 1 (+ (hum/curr-time ctx) 0))

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Here's an example:
   (:require [hum.core :as hum])
 
 ; create a WebAudio contet
-(def ctx (hum/create-context))
+(defonce ctx (hum/create-context))
 
 ; create an oscilator, filter and amp
 (def vco (hum/create-osc ctx :sawtooth))
@@ -39,9 +39,10 @@ Here's an example:
 ; connect the amp to speakers
 (hum/connect-output amp)
 
-; set envelope for filter
-(hum/set-value-at vcf :frequency 100 (+ (hum/curr-time ctx) 0))
-(hum/linear-fade vcf :frequency 1000 (+ (hum/curr-time ctx) 10))
+; move filter frequency between values using an exponential envelope.
+(hum/trigger-env vcf :frequency 
+                 (hum/exponential-env [100 10000 1000 5000 100] [4 3 2 1])
+                 (hum/curr-time ctx))
 
 ; set envelope for amp
 (hum/set-value-at amp :gain 1 (+ (hum/curr-time ctx) 0))

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Here's an example:
 (hum/connect-output amp)
 
 ; set envelope for filter
-(hum/set-value-at vcf :frequency 100 (+ (hum/curr-time ctx)) 0)
+(hum/set-value-at vcf :frequency 100 (+ (hum/curr-time ctx) 0))
 (hum/linear-fade vcf :frequency 1000 (+ (hum/curr-time ctx) 10))
 
 ; set envelope for amp
-(hum/set-value-at amp :gain 1 (+ (hum/curr-time ctx)) 0)
+(hum/set-value-at amp :gain 1 (+ (hum/curr-time ctx) 0))
 (hum/linear-fade amp :gain 0 (+ (hum/curr-time ctx) 10))
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,19 +22,30 @@ Here's an example:
 (ns myapp.core
   (:require [hum.core :as hum])
 
+; create a WebAudio contet
 (def ctx (hum/create-context))
+
+; create an oscilator, filter and amp
 (def vco (hum/create-osc ctx :sawtooth))
 (def vcf (hum/create-biquad-filter ctx))
-(def output (hum/create-gain ctx))
+(def amp (hum/create-gain ctx))
 
-; connect the VCO to the VCF and on to the output gain node
-(hum/connect vco vcf output)
+; connect them together in series
+(hum/connect vco vcf amp)
 
+; start the oscilator
 (hum/start-osc vco)
 
-(hum/connect-output output)
+; connect the amp to speakers
+(hum/connect-output amp)
 
-(hum/note-on output vco 440)
+; set envelope for filter
+(hum/set-value-at vcf :frequency 100 (+ (hum/curr-time ctx)) 0)
+(hum/linear-fade vcf :frequency 1000 (+ (hum/curr-time ctx) 10))
+
+; set envelope for amp
+(hum/set-value-at amp :gain 1 (+ (hum/curr-time ctx)) 0)
+(hum/linear-fade amp :gain 0 (+ (hum/curr-time ctx) 10))
 ```
 
 ## What now? / Contributing

--- a/src/hum/core.cljs
+++ b/src/hum/core.cljs
@@ -9,14 +9,14 @@
        (set! (.-type osc) osc-type)
        osc)))
 
-(defn set-vale 
+(defn set-value 
   "Set nodes attribute."
   [node param value]
   (aset node (name param) "value" value))
 
-(defn set-value-at [node param value time]
+(defn set-value-at 
   "Set nodes param value at time."
-  [node param vale time]
+  [node param value time]
   (.setValueAtTime (aget node (name param)) value time))
 
 (defn linear-fade 

--- a/src/hum/core.cljs
+++ b/src/hum/core.cljs
@@ -10,11 +10,9 @@
        osc)))
 
 (defn set-param! 
-  "Allow setting of AudioNode's AudioParam attributes.
-  
-  eg. (set-param! gain-node :gain 0.5)"
+  "Allow setting of AudioNode's AudioParam attributes."
   [node param value]
-  (set! (aget node (name param) "value") value))
+  (aset node (name param) "value" value))
 
 (defn set-gain-to [channel val]
   (set! (.-value (.-gain channel)) val))

--- a/src/hum/core.cljs
+++ b/src/hum/core.cljs
@@ -9,10 +9,25 @@
        (set! (.-type osc) osc-type)
        osc)))
 
-(defn set-param! 
-  "Allow setting of AudioNode's AudioParam attributes."
+(defn set-vale 
+  "Set nodes attribute."
   [node param value]
   (aset node (name param) "value" value))
+
+(defn set-value-at [node param value time]
+  "Set nodes param value at time."
+  [node param vale time]
+  (.setValueAtTime (aget node (name param)) value time))
+
+(defn linear-fade 
+  "Fade to nodes param value by time linearly."
+  [node param value time]
+  (.linearRampToValueAtTime (aget node (name param)) value time))
+
+(defn exponential-fade
+  "Fade to nodes param value by time exponentially."
+  [node param value time]
+  (.exponentialRampToValueAtTime (aget node (name param)) value time))
 
 (defn set-gain-to [channel val]
   (set! (.-value (.-gain channel)) val))

--- a/src/hum/core.cljs
+++ b/src/hum/core.cljs
@@ -32,6 +32,36 @@
 (defn set-gain-to [channel val]
   (set! (.-value (.-gain channel)) val))
 
+; envelope stuff
+
+(defn trigger-env
+  "Triggers envelopes in the form of [[curve-function value time]...]"
+  ([node param envelope time] 
+    (doall (map (fn [[f v t]] (apply f [node param v (+ time t)])) 
+                envelope))))
+
+(defn env-of-type
+  "Creates an envelope that transitions between times with func.
+  First time is set as start value hence times is shorter. 
+  All others interpolated between."
+
+  [func values times]
+  (cons [set-value-at (first values) 0]
+        (map (fn [value time] [func value time]) 
+             (rest values) times)))
+
+(defn linear-env      
+  "Creates a linear envelope."
+  [values times] (env-of-type linear-fade values times))
+
+(defn exponential-env 
+  "Creates an exponential envelope."
+  [values times] (env-of-type exponential-fade values times))
+
+(defn step-env
+  "Creates an envelope with stepped values."
+  [values times] (env-of-type set-value-at values times))
+
 (defn create-gain
   ([ctx]
      (create-gain ctx 0))

--- a/src/hum/core.cljs
+++ b/src/hum/core.cljs
@@ -9,6 +9,13 @@
        (set! (.-type osc) osc-type)
        osc)))
 
+(defn set-param! 
+  "Allow setting of AudioNode's AudioParam attributes.
+  
+  eg. (set-param! gain-node :gain 0.5)"
+  [node param value]
+  (set! (aget node (name param) "value") value))
+
 (defn set-gain-to [channel val]
   (set! (.-value (.-gain channel)) val))
 

--- a/src/hum/core.cljs
+++ b/src/hum/core.cljs
@@ -32,36 +32,6 @@
 (defn set-gain-to [channel val]
   (set! (.-value (.-gain channel)) val))
 
-; envelope stuff
-
-(defn trigger-env
-  "Triggers envelopes in the form of [[curve-function value time]...]"
-  ([node param envelope time] 
-    (doall (map (fn [[f v t]] (apply f [node param v (+ time t)])) 
-                envelope))))
-
-(defn env-of-type
-  "Creates an envelope that transitions between times with func.
-  First time is set as start value hence times is shorter. 
-  All others interpolated between."
-
-  [func values times]
-  (cons [set-value-at (first values) 0]
-        (map (fn [value time] [func value time]) 
-             (rest values) times)))
-
-(defn linear-env      
-  "Creates a linear envelope."
-  [values times] (env-of-type linear-fade values times))
-
-(defn exponential-env 
-  "Creates an exponential envelope."
-  [values times] (env-of-type exponential-fade values times))
-
-(defn step-env
-  "Creates an envelope with stepped values."
-  [values times] (env-of-type set-value-at values times))
-
 (defn create-gain
   ([ctx]
      (create-gain ctx 0))


### PR DESCRIPTION
See example in README for details of how to operate exponential-env, linear-env and step-env behave similarly.

trigger-env works as follows fro envelopes with stepped linear and exponential segments:

``` clojure
(hum/trigger-env vcf :frequency 
                 [[hum/set-value-at 100 1]
                  [hum/exponential-fade 1000 3]
                  [hum/linear-fade 100 5]]
                 (hum/curr-time ctx))
```
